### PR TITLE
Add linting to widget.js and auto-fix violations

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "webpack-dev-server --config webpack.dev.js --host 0.0.0.0",
     "build": "webpack --config webpack.prod.js",
-    "lint": "./node_modules/.bin/eslint src/index.js"
+    "lint": "./node_modules/.bin/eslint \"{src,static}/**/*.js\""
   },
   "repository": {
     "type": "git",

--- a/static/widget.js
+++ b/static/widget.js
@@ -1,167 +1,167 @@
 (function() {
-  'use strict';
-  var DOM_ID = 'EARTH_DAY_LIVE';
-  var CLOSED_COOKIE = '_EARTH_DAY_LIVE_WIDGET_CLOSED_';
-  var NOW = new Date().getTime();
-  var MS_PER_DAY = 86400000;
+  'use strict'
+  var DOM_ID = 'EARTH_DAY_LIVE'
+  var CLOSED_COOKIE = '_EARTH_DAY_LIVE_WIDGET_CLOSED_'
+  var NOW = new Date().getTime()
+  var MS_PER_DAY = 86400000
 
   // user-configurable options
-  var options = window.EARTH_DAY_LIVE_OPTIONS || {};
-  var iframeHost = options.iframeHost !== undefined ? options.iframeHost : 'https://widget.earthdaylive2020.org';
-  var websiteName = options.websiteName || null;
-  var footerDisplayStartDate = options.footerDisplayStartDate || new Date(2019, 12, 1);       // January 1st, 2020 - arbitrary date in the past
-  var fullPageDisplayStartDate = options.fullPageDisplayStartDate || new Date(2020, 3, 22);  // April 22nd, 2020
-  var forceFullPageWidget = !!options.forceFullPageWidget;
-  var cookieExpirationDays = parseFloat(options.cookieExpirationDays || 1);
-  var alwaysShowWidget = !!(options.alwaysShowWidget || window.location.hash.indexOf('ALWAYS_SHOW_EARTH_DAY_LIVE') !== -1);
-  var disableGoogleAnalytics = !!options.disableGoogleAnalytics;
-  var showCloseButtonOnFullPageWidget = !!options.showCloseButtonOnFullPageWidget;
-  var language = getLanguage();
+  var options = window.EARTH_DAY_LIVE_OPTIONS || {}
+  var iframeHost = options.iframeHost !== undefined ? options.iframeHost : 'https://widget.earthdaylive2020.org'
+  var websiteName = options.websiteName || null
+  var footerDisplayStartDate = options.footerDisplayStartDate || new Date(2019, 12, 1)       // January 1st, 2020 - arbitrary date in the past
+  var fullPageDisplayStartDate = options.fullPageDisplayStartDate || new Date(2020, 3, 22)  // April 22nd, 2020
+  var forceFullPageWidget = !!options.forceFullPageWidget
+  var cookieExpirationDays = parseFloat(options.cookieExpirationDays || 1)
+  var alwaysShowWidget = !!(options.alwaysShowWidget || window.location.hash.indexOf('ALWAYS_SHOW_EARTH_DAY_LIVE') !== -1)
+  var disableGoogleAnalytics = !!options.disableGoogleAnalytics
+  var showCloseButtonOnFullPageWidget = !!options.showCloseButtonOnFullPageWidget
+  var language = getLanguage()
 
   function getIframeSrc() {
-    var src = iframeHost;
-    src += language === 'en' ? '/index.html?' : '/index-' + language + '.html?';
+    var src = iframeHost
+    src += language === 'en' ? '/index.html?' : '/index-' + language + '.html?'
 
     var urlParams = [
       ['hostname', window.location.host],
       ['fullPageDisplayStartDate', fullPageDisplayStartDate.toISOString()],
       ['language', language]
-    ];
+    ]
 
-    forceFullPageWidget && urlParams.push(['forceFullPageWidget', 'true']);
-    showCloseButtonOnFullPageWidget && urlParams.push(['showCloseButtonOnFullPageWidget', 'true']);
-    disableGoogleAnalytics && urlParams.push(['googleAnalytics', 'false']);
-    websiteName && urlParams.push(['websiteName', encodeURI(websiteName)]);
+    forceFullPageWidget && urlParams.push(['forceFullPageWidget', 'true'])
+    showCloseButtonOnFullPageWidget && urlParams.push(['showCloseButtonOnFullPageWidget', 'true'])
+    disableGoogleAnalytics && urlParams.push(['googleAnalytics', 'false'])
+    websiteName && urlParams.push(['websiteName', encodeURI(websiteName)])
 
     var params = urlParams.map(function(el) {
-      return el.join('=');
-    });
+      return el.join('=')
+    })
 
-    return src + params.join('&');
+    return src + params.join('&')
   }
 
   function createIframe() {
-    var wrapper = document.createElement('div');
-    wrapper.id = DOM_ID;
-    var iframe = document.createElement('iframe');
-    iframe.src = getIframeSrc();
-    iframe.frameBorder = 0;
-    iframe.allowTransparency = true;
-    wrapper.appendChild(iframe);
-    document.body.appendChild(wrapper);
-    iframe.contentWindow.focus();
-    return wrapper;
+    var wrapper = document.createElement('div')
+    wrapper.id = DOM_ID
+    var iframe = document.createElement('iframe')
+    iframe.src = getIframeSrc()
+    iframe.frameBorder = 0
+    iframe.allowTransparency = true
+    wrapper.appendChild(iframe)
+    document.body.appendChild(wrapper)
+    iframe.contentWindow.focus()
+    return wrapper
   }
 
   function getLanguage() {
-    var language = 'en';
+    var language = 'en'
 
     // Spanish is specified or no language is set and browser is set to spanish
     if (options.language === 'es' || (!options.language && navigator && navigator.language.match(/^es/))) {
-      language = 'es';
+      language = 'es'
     }
 
     // German is specified or no language is set and browser is set to German
     if (options.language === 'de' || (!options.language && navigator && navigator.language.match(/^de/))) {
-      language = 'de';
+      language = 'de'
     }
 
     // Czech is specified or no language is set and browser is set to German
     if (options.language === 'cs' || (!options.language && navigator && navigator.language.match(/^cs/))) {
-      language = 'cs';
+      language = 'cs'
     }
 
     // French is specified or no language is set and browser is set to French
     if (options.language === 'fr' || (!options.language && navigator && navigator.language.match(/^fr/))) {
-      language = 'fr';
+      language = 'fr'
     }
 
     // Dutch is specified or no language is set and browser is set to Dutch
     if (options.language === 'nl' || (!options.language && navigator && navigator.language.match(/^nl/))) {
-      language = 'nl';
+      language = 'nl'
     }
 
     // Turkish is specified or no language is set and browser is set to Turkish
     if (options.language === 'tr' || (!options.language && navigator && navigator.language.match(/^tr/))) {
-      language = 'tr';
+      language = 'tr'
     }
 
     // Portuguese is specified or no language is set and browser is set to Portuguese
     if (options.language === 'pt' || (!options.language && navigator && navigator.language.match(/^pt/))) {
-      language = 'pt';
+      language = 'pt'
     }
 
     // Italian is specified or no language is set and browser is set to Italian
     if (options.language === 'it' || (!options.language && navigator && navigator.language.match(/^it/))) {
-      language = 'it';
+      language = 'it'
     }
 
-    return language;
+    return language
   }
 
   function maximize() {
-    document.getElementById(DOM_ID).style.width = '100%';
-    document.getElementById(DOM_ID).style.height = '100%';
+    document.getElementById(DOM_ID).style.width = '100%'
+    document.getElementById(DOM_ID).style.height = '100%'
   }
 
   function closeWindow() {
-    document.getElementById(DOM_ID).remove();
-    window.removeEventListener('message', receiveMessage);
-    setCookie(CLOSED_COOKIE, 'true', cookieExpirationDays);
+    document.getElementById(DOM_ID).remove()
+    window.removeEventListener('message', receiveMessage)
+    setCookie(CLOSED_COOKIE, 'true', cookieExpirationDays)
   }
 
   function navigateToLink(linkUrl) {
-    document.location = linkUrl;
+    document.location = linkUrl
   }
 
   function injectCSS(id, css) {
-    var style = document.createElement('style');
-    style.type = 'text/css';
-    style.id = id;
+    var style = document.createElement('style')
+    style.type = 'text/css'
+    style.id = id
     if (style.styleSheet) {
-      style.styleSheet.cssText = css;
+      style.styleSheet.cssText = css
     }
     else {
-      style.appendChild(document.createTextNode(css));
+      style.appendChild(document.createTextNode(css))
     }
-    document.head.appendChild(style);
+    document.head.appendChild(style)
   }
 
   function setCookie(name, value, expirationDays) {
-    var d = new Date();
-    d.setTime(d.getTime()+(expirationDays * MS_PER_DAY));
+    var d = new Date()
+    d.setTime(d.getTime()+(expirationDays * MS_PER_DAY))
 
-    var expires = 'expires='+d.toGMTString();
-    document.cookie = name + '=' + value + '; ' + expires + '; path=/';
+    var expires = 'expires='+d.toGMTString()
+    document.cookie = name + '=' + value + '; ' + expires + '; path=/'
   }
 
   function getCookie(cookieName) {
-    var name = cookieName + '=';
-    var ca = document.cookie.split(';');
-    var c;
+    var name = cookieName + '='
+    var ca = document.cookie.split(';')
+    var c
 
     for(var i = 0; i < ca.length; i++) {
-      c = ca[i].trim();
+      c = ca[i].trim()
       if (c.indexOf(name) == 0) {
-        return c.substring(name.length, c.length);
+        return c.substring(name.length, c.length)
       }
     }
 
-    return '';
+    return ''
   }
 
   function receiveMessage(event) {
-    if (!event.data.EARTH_DAY_LIVE) return;
-    if (event.origin.lastIndexOf(iframeHost, 0) !== 0) return;
+    if (!event.data.EARTH_DAY_LIVE) return
+    if (event.origin.lastIndexOf(iframeHost, 0) !== 0) return
 
     switch (event.data.action) {
-      case 'maximize':
-        return maximize();
-      case 'closeButtonClicked':
-        return closeWindow();
-      case 'buttonClicked':
-        if (event.data.linkUrl.lastIndexOf('http', 0) !== 0) return;
-        return navigateToLink(event.data.linkUrl);
+    case 'maximize':
+      return maximize()
+    case 'closeButtonClicked':
+      return closeWindow()
+    case 'buttonClicked':
+      if (event.data.linkUrl.lastIndexOf('http', 0) !== 0) return
+      return navigateToLink(event.data.linkUrl)
     }
   }
 
@@ -173,52 +173,52 @@
    * 4. We haven't set alwaysShowWidget to be true in the config.
    */
   function iFrameShouldNotBeShown() {
-    if (alwaysShowWidget) return false;
+    if (alwaysShowWidget) return false
 
     return (footerDisplayStartDate.getTime() > NOW && fullPageDisplayStartDate.getTime() > NOW)
       || new Date(fullPageDisplayStartDate.getTime() + MS_PER_DAY) < NOW
-      || !!getCookie(CLOSED_COOKIE);
+      || !!getCookie(CLOSED_COOKIE)
   }
 
   function initializeInterface() {
     if (iFrameShouldNotBeShown()) {
-      return;
+      return
     }
 
-    createIframe();
+    createIframe()
 
-    var iFrameHeight = getIframeHeight();
+    var iFrameHeight = getIframeHeight()
 
     injectCSS('EARTH_DAY_LIVE_CSS',
       '#' + DOM_ID + ' { position: fixed; right: 0; left: 0; bottom: 0px; width: 100%; height: ' + iFrameHeight + '; z-index: 20000; -webkit-overflow-scrolling: touch; overflow: hidden; } ' +
       '#' + DOM_ID + ' iframe { width: 100%; height: 100%; }'
-    );
+    )
 
     // listen for messages from iframe
-    window.addEventListener('message', receiveMessage);
+    window.addEventListener('message', receiveMessage)
 
-    document.removeEventListener('DOMContentLoaded', initializeInterface);
+    document.removeEventListener('DOMContentLoaded', initializeInterface)
   }
 
   function getIframeHeight() {
 
-    var isProbablyMobile = window.innerWidth < 600;
+    var isProbablyMobile = window.innerWidth < 600
 
     if (isProbablyMobile) {
-      return '200px';
+      return '200px'
     } else {
-      return '145px';
+      return '145px'
     }
   }
 
   // Wait for DOM content to load.
   switch(document.readyState) {
-    case 'complete':
-    case 'loaded':
-    case 'interactive':
-      initializeInterface();
-      break;
-    default:
-      document.addEventListener('DOMContentLoaded', initializeInterface);
+  case 'complete':
+  case 'loaded':
+  case 'interactive':
+    initializeInterface()
+    break
+  default:
+    document.addEventListener('DOMContentLoaded', initializeInterface)
   }
-})();
+})()


### PR DESCRIPTION
We were running ESLint on `src/index.js` but not `static/widget.js`.

Now, when you run `npm run lint`, we'll check all JS files in `src/` and `static/`, which picks up `widget.js`.

I ran `npm run lint -- --fix` to auto-fix all of the errors in `widget.js` and made no manual edits.