### PR TITLE
Mark project as private to prevent accidental publishing to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "earth-day-live-widget",
+  "private": true,
   "version": "1.0.0",
   "description": "Earth Day Live widget so anyone can join the Earth Day livestream",
   "main": "index.js",


### PR DESCRIPTION
[`package.json` has a `private` option][0]. If it's set to `true`, npm will refuse to publish it to its registry. In the unlikely event that someone accidentally runs `npm publish`, this will fail with an error.

I think it's also useful to have this to communicate that this isn't to be published—it's an "end developer" project, not an open source package.

[0]: https://docs.npmjs.com/files/package.json#private